### PR TITLE
Add ai sdk

### DIFF
--- a/packages/database/prisma/migrations/20250913052608_add_chat/migration.sql
+++ b/packages/database/prisma/migrations/20250913052608_add_chat/migration.sql
@@ -1,0 +1,98 @@
+-- CreateEnum
+CREATE TYPE "public"."visibility" AS ENUM ('PUBLIC', 'PRIVATE');
+
+-- CreateEnum
+CREATE TYPE "public"."artifact_kind" AS ENUM ('TEXT', 'CODE', 'IMAGE', 'SHEET');
+
+-- CreateTable
+CREATE TABLE "public"."Chat" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "title" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "visibility" "public"."visibility" NOT NULL DEFAULT 'PRIVATE',
+    "lastContext" JSONB,
+
+    CONSTRAINT "Chat_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Message_v2" (
+    "id" UUID NOT NULL,
+    "chatId" UUID NOT NULL,
+    "role" TEXT NOT NULL,
+    "parts" JSONB NOT NULL,
+    "attachments" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_v2_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Vote_v2" (
+    "chatId" UUID NOT NULL,
+    "messageId" UUID NOT NULL,
+    "isUpvoted" BOOLEAN NOT NULL,
+
+    CONSTRAINT "Vote_v2_pkey" PRIMARY KEY ("chatId","messageId")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Document" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "title" TEXT NOT NULL,
+    "content" TEXT,
+    "text" "public"."artifact_kind" NOT NULL DEFAULT 'TEXT',
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id","createdAt")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Suggestion" (
+    "id" UUID NOT NULL,
+    "documentId" UUID NOT NULL,
+    "documentCreatedAt" TIMESTAMP(3) NOT NULL,
+    "originalText" TEXT NOT NULL,
+    "suggestedText" TEXT NOT NULL,
+    "description" TEXT,
+    "isResolved" BOOLEAN NOT NULL DEFAULT false,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Suggestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Stream" (
+    "id" UUID NOT NULL,
+    "chatId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Stream_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."Chat" ADD CONSTRAINT "Chat_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Message_v2" ADD CONSTRAINT "Message_v2_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Vote_v2" ADD CONSTRAINT "Vote_v2_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Vote_v2" ADD CONSTRAINT "Vote_v2_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "public"."Message_v2"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Document" ADD CONSTRAINT "Document_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Suggestion" ADD CONSTRAINT "Suggestion_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Suggestion" ADD CONSTRAINT "Suggestion_documentId_documentCreatedAt_fkey" FOREIGN KEY ("documentId", "documentCreatedAt") REFERENCES "public"."Document"("id", "createdAt") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Stream" ADD CONSTRAINT "Stream_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20250913074204_rm_vote/migration.sql
+++ b/packages/database/prisma/migrations/20250913074204_rm_vote/migration.sql
@@ -1,0 +1,36 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Message_v2` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Vote_v2` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."Message_v2" DROP CONSTRAINT "Message_v2_chatId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Vote_v2" DROP CONSTRAINT "Vote_v2_chatId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Vote_v2" DROP CONSTRAINT "Vote_v2_messageId_fkey";
+
+-- DropTable
+DROP TABLE "public"."Message_v2";
+
+-- DropTable
+DROP TABLE "public"."Vote_v2";
+
+-- CreateTable
+CREATE TABLE "public"."Message" (
+    "id" UUID NOT NULL,
+    "chatId" UUID NOT NULL,
+    "role" TEXT NOT NULL,
+    "parts" JSONB NOT NULL,
+    "attachments" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."Message" ADD CONSTRAINT "Message_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -82,7 +82,6 @@ model Chat {
   // Relations
   user     User      @relation(fields: [userId], references: [id])
   messages Message[]
-  votes    Vote[]
   streams  Stream[]
 
   @@map("Chat")
@@ -98,23 +97,10 @@ model Message {
 
   // Relations
   chat  Chat   @relation(fields: [chatId], references: [id])
-  votes Vote[]
 
-  @@map("Message_v2")
+  @@map("Message")
 }
 
-model Vote {
-  chatId    String  @db.Uuid
-  messageId String  @db.Uuid
-  isUpvoted Boolean
-
-  // Relations
-  chat    Chat    @relation(fields: [chatId], references: [id])
-  message Message @relation(fields: [messageId], references: [id])
-
-  @@id([chatId, messageId])
-  @@map("Vote_v2")
-}
 
 model Document {
   id        String       @default(uuid()) @db.Uuid

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -8,17 +8,19 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-
 model User {
-  id            String    @id
+  id            String       @id
   name          String
   email         String
-  emailVerified Boolean   @default(false)
+  emailVerified Boolean      @default(false)
   image         String?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @default(now()) @updatedAt
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @default(now()) @updatedAt
   sessions      Session[]
   accounts      Account[]
+  Chat          Chat[]
+  Document      Document[]
+  Suggestion    Suggestion[]
 
   @@unique([email])
   @@map("user")
@@ -67,4 +69,111 @@ model Verification {
   updatedAt  DateTime @default(now()) @updatedAt
 
   @@map("verification")
+}
+
+model Chat {
+  id          String     @id @default(uuid()) @db.Uuid
+  createdAt   DateTime   @default(now())
+  title       String
+  userId      String
+  visibility  Visibility @default(PRIVATE)
+  lastContext Json? // LanguageModelV2Usage
+
+  // Relations
+  user     User      @relation(fields: [userId], references: [id])
+  messages Message[]
+  votes    Vote[]
+  streams  Stream[]
+
+  @@map("Chat")
+}
+
+model Message {
+  id          String   @id @default(uuid()) @db.Uuid
+  chatId      String   @db.Uuid
+  role        String
+  parts       Json
+  attachments Json
+  createdAt   DateTime @default(now())
+
+  // Relations
+  chat  Chat   @relation(fields: [chatId], references: [id])
+  votes Vote[]
+
+  @@map("Message_v2")
+}
+
+model Vote {
+  chatId    String  @db.Uuid
+  messageId String  @db.Uuid
+  isUpvoted Boolean
+
+  // Relations
+  chat    Chat    @relation(fields: [chatId], references: [id])
+  message Message @relation(fields: [messageId], references: [id])
+
+  @@id([chatId, messageId])
+  @@map("Vote_v2")
+}
+
+model Document {
+  id        String       @default(uuid()) @db.Uuid
+  createdAt DateTime     @default(now())
+  title     String
+  content   String?
+  kind      ArtifactKind @default(TEXT) @map("text")
+  userId    String
+
+  // Relations
+  user        User         @relation(fields: [userId], references: [id])
+  suggestions Suggestion[]
+
+  @@id([id, createdAt])
+  @@map("Document")
+}
+
+model Suggestion {
+  id                String   @id @default(uuid()) @db.Uuid
+  documentId        String   @db.Uuid
+  documentCreatedAt DateTime
+  originalText      String
+  suggestedText     String
+  description       String?
+  isResolved        Boolean  @default(false)
+  userId            String
+  createdAt         DateTime @default(now())
+
+  // Relations
+  user     User     @relation(fields: [userId], references: [id])
+  document Document @relation(fields: [documentId, documentCreatedAt], references: [id, createdAt])
+
+  @@map("Suggestion")
+}
+
+model Stream {
+  id        String   @id @default(uuid()) @db.Uuid
+  chatId    String   @db.Uuid
+  createdAt DateTime @default(now())
+
+  // Relations
+  chat Chat @relation(fields: [chatId], references: [id])
+
+  @@map("Stream")
+}
+
+// Enums
+enum Visibility {
+  PUBLIC
+  PRIVATE
+
+  @@map("visibility")
+}
+
+enum ArtifactKind {
+  TEXT
+  CODE
+  IMAGE
+  SHEET
+
+  @@map("artifact_kind")
 }


### PR DESCRIPTION
This pull request introduces a new set of core models for chat, document, and suggestion functionality in the database schema, while also revising message and vote handling. The changes include new tables and enums for chat and document management, removal of the previous message and vote tables, and updates to the Prisma schema to reflect these changes.

**Database schema additions:**

* Added new tables: `Chat`, `Message`, `Document`, `Suggestion`, and `Stream`, along with enums for `visibility` and `artifact_kind` to support chat and document features.
* Updated Prisma schema (`schema.prisma`) to define new models: `Chat`, `Message`, `Document`, `Suggestion`, and `Stream`, and corresponding enums `Visibility` and `ArtifactKind`.

**Schema relationships and user model updates:**

* Updated the `User` model to include relations to the new `Chat`, `Document`, and `Suggestion` models.

**Message and vote table revisions:**

* Dropped legacy tables `Message_v2` and `Vote_v2`, and replaced them with a new `Message` table, updating foreign key relationships accordingly.

These changes lay the foundation for chat, document, and suggestion features, and clean up previous message and vote implementations.