### PR TITLE
fix sidebar recent chats loading

### DIFF
--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -34,8 +34,15 @@ export function AppSidebar() {
   const lastChatsSignature = useRef<string>("");
 
   async function getSession() {
-    const { data: session } = await authClient.getSession();
-    setUser(session?.user || null);
+    try {
+      const { data: session } = await authClient.getSession();
+      setUser(session?.user || null);
+      if (!session?.user) {
+        setIsLoading(false);
+      }
+    } catch (error) {
+      console.error("Error getting session:", error);
+    }
   }
 
   async function handleLogout() {


### PR DESCRIPTION
## Problem
In the **Sidebar → Recent Chats** section:
- When no user is logged in, the sidebar always showed **"Loading..."** indefinitely.

## Solution
- Updated logic to show **"No recent chats"** when no user is logged in.

## Verification
- ✅ Without user: shows **"No recent chats"** (no infinite loading).
- ✅ With logged-in user: correctly shows loading → then actual chat titles.

#11 
