### PR TITLE
Demo prompt refactor

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,6 +10,7 @@ import { generateUUID } from "@/lib/utils";
 import { authClient } from "@/lib/auth-client";
 import { AuthDialog } from "@/components/auth-dialog";
 import { FileUIPart } from "ai";
+import DemoPromptWidget from "@/components/widgets/DemoPrompts";
 
 export default function Chat() {
   const [input, setInput] = useState("");
@@ -89,7 +90,13 @@ export default function Chat() {
         personality={personalityName}
         setPersonality={setPersonalityName}
       />
-      <WelcomeScreen />
+      <div className="mt-3 flex flex-col">
+        <DemoPromptWidget 
+        className="w-full" 
+        setInput={setInput}
+        setPersonality={setPersonalityName}
+        />
+      </div>
       <AuthDialog
         open={authOpen}
         onOpenChange={setAuthOpen}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -91,10 +91,10 @@ export default function Chat() {
         setPersonality={setPersonalityName}
       />
       <div className="mt-3 flex flex-col">
-        <DemoPromptWidget 
-        className="w-full" 
-        setInput={setInput}
-        setPersonality={setPersonalityName}
+        <DemoPromptWidget
+          className="w-full"
+          setInput={setInput}
+          setPersonality={setPersonalityName}
         />
       </div>
       <AuthDialog

--- a/apps/web/components/welcome-screen.tsx
+++ b/apps/web/components/welcome-screen.tsx
@@ -4,7 +4,7 @@ import { ClockWidget } from "@/components/widgets/ClockWidget";
 import { WeatherWidget } from "@/components/widgets/WeatherWidget";
 import { NewsWidget } from "@/components/widgets/NewsWidget";
 import { CryptoWidget } from "@/components/widgets/CryptoWidget";
-import { DemoPromptWidget } from "@/components/widgets/DemoPromptWidget";
+import { DemoPromptWidget } from "@/components/widgets/DemoPrompts";
 
 interface WelcomeScreenProps {
   className?: string;
@@ -20,7 +20,7 @@ export function WelcomeScreen({ className }: WelcomeScreenProps) {
       {/* <CryptoWidget />
         <NewsWidget className="bg-muted/30 dark:bg-muted/10 sm:col-span-2 lg:col-span-3" /> */}
       {/* </div> */}
-      <DemoPromptWidget className="w-full" />
+      {/* <DemoPromptWidget className="w-full" /> */}
     </div>
   );
 }

--- a/apps/web/components/widgets/DemoPrompts.tsx
+++ b/apps/web/components/widgets/DemoPrompts.tsx
@@ -1,30 +1,24 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { generateUUID } from "@/lib/utils";
 import { PROMPTS, Prompts } from "@/lib/prompts/demo-prompts";
 import { Button } from "@workspace/ui/components/button";
 import { cn } from "@workspace/ui/lib/utils";
 
-export function DemoPromptWidget({ className }: { className?: string }) {
+interface DemoPromptWidgetProps {
+  className?: string;
+  setInput: (input: string) => void;
+  setPersonality: (personality: string) => void;
+}
+
+export function DemoPromptWidget({ className, setInput, setPersonality }: DemoPromptWidgetProps) {
   const [prompts, setPrompts] = useState<Prompts[]>(
     [...PROMPTS].sort(() => Math.random() - 0.5).slice(0, 6),
   );
-  const router = useRouter();
 
   function handleClick({ prompt }: { prompt: Prompts }) {
-    const encodedInput = encodeURIComponent(prompt?.prompt ?? "");
-    const encodedPersonality = encodeURIComponent(
-      (prompt?.personality?.toLowerCase() ?? "") || "",
-    );
-    const newChatId = generateUUID();
-    router.replace(
-      `/chat/${newChatId}?input=${encodedInput}&personality=${encodedPersonality}`,
-      {
-        scroll: false,
-      },
-    );
+    setInput(prompt?.prompt ?? "");
+    setPersonality(prompt?.personality?.toLowerCase() ?? "");
   }
 
   return (

--- a/apps/web/components/widgets/DemoPrompts.tsx
+++ b/apps/web/components/widgets/DemoPrompts.tsx
@@ -11,7 +11,11 @@ interface DemoPromptWidgetProps {
   setPersonality: (personality: string) => void;
 }
 
-export function DemoPromptWidget({ className, setInput, setPersonality }: DemoPromptWidgetProps) {
+export function DemoPromptWidget({
+  className,
+  setInput,
+  setPersonality,
+}: DemoPromptWidgetProps) {
   const [prompts, setPrompts] = useState<Prompts[]>(
     [...PROMPTS].sort(() => Math.random() - 0.5).slice(0, 6),
   );


### PR DESCRIPTION
This pull request updates the demo prompt widget functionality and its integration in the chat and welcome screen components. The main changes include refactoring the `DemoPromptWidget` (now `DemoPrompts`) to use callback props instead of navigation, updating imports and usages accordingly, and removing its display from the welcome screen.

**Component Refactoring and API Changes:**

* Renamed `DemoPromptWidget.tsx` to `DemoPrompts.tsx`, updated the component to accept `setInput` and `setPersonality` callback props instead of handling navigation internally, and removed the dependency on `useRouter` and `generateUUID`. The click handler now directly sets the input and personality in the parent component.

**Integration Updates:**

* Updated the import and usage of `DemoPromptWidget` in `page.tsx` to use the new `DemoPrompts` component and pass the required callback props. The widget is now rendered in the chat page instead of the welcome screen. [[1]](diffhunk://#diff-fd023d75d1ed8133295c3359120c1f334b252c95341a0c411018fd0e8411c5e3R13) [[2]](diffhunk://#diff-fd023d75d1ed8133295c3359120c1f334b252c95341a0c411018fd0e8411c5e3L92-R99)

* Updated the import in `welcome-screen.tsx` to reference the new `DemoPrompts` file and commented out its usage, removing the widget from the welcome screen UI. [[1]](diffhunk://#diff-d4497cc26b21b4a1dbaea070e17547c9e7de37f7a27c9a21f341f93492c14aeaL7-R7) [[2]](diffhunk://#diff-d4497cc26b21b4a1dbaea070e17547c9e7de37f7a27c9a21f341f93492c14aeaL23-R23)