### PR TITLE
Db schema updates

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "db:generate": "prisma generate",
-    "db:migrate": "prisma migrate dev --skip-generate",
+    "db:migrate": "prisma migrate dev",
     "db:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio"
   },

--- a/packages/database/prisma/migrations/20251213123825_rm_unwanted_tables_from_schema/migration.sql
+++ b/packages/database/prisma/migrations/20251213123825_rm_unwanted_tables_from_schema/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Document` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Stream` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Suggestion` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Document" DROP CONSTRAINT "Document_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Stream" DROP CONSTRAINT "Stream_chatId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Suggestion" DROP CONSTRAINT "Suggestion_documentId_documentCreatedAt_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Suggestion" DROP CONSTRAINT "Suggestion_userId_fkey";
+
+-- DropTable
+DROP TABLE "Document";
+
+-- DropTable
+DROP TABLE "Stream";
+
+-- DropTable
+DROP TABLE "Suggestion";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -18,8 +18,6 @@ model User {
   sessions      Session[]
   accounts      Account[]
   Chat          Chat[]
-  Document      Document[]
-  Suggestion    Suggestion[]
   usage         UserUsage[]
   integrations  Integration[]
 
@@ -99,7 +97,6 @@ model Chat {
   // Relations
   user     User      @relation(fields: [userId], references: [id])
   messages Message[]
-  streams  Stream[]
 
   @@map("Chat")
 }
@@ -116,51 +113,6 @@ model Message {
   chat Chat @relation(fields: [chatId], references: [id])
 
   @@map("Message")
-}
-
-model Document {
-  id        String       @default(uuid()) @db.Uuid
-  createdAt DateTime     @default(now())
-  title     String
-  content   String?
-  kind      ArtifactKind @default(TEXT) @map("text")
-  userId    String
-
-  // Relations
-  user        User         @relation(fields: [userId], references: [id])
-  suggestions Suggestion[]
-
-  @@id([id, createdAt])
-  @@map("Document")
-}
-
-model Suggestion {
-  id                String   @id @default(uuid()) @db.Uuid
-  documentId        String   @db.Uuid
-  documentCreatedAt DateTime
-  originalText      String
-  suggestedText     String
-  description       String?
-  isResolved        Boolean  @default(false)
-  userId            String
-  createdAt         DateTime @default(now())
-
-  // Relations
-  user     User     @relation(fields: [userId], references: [id])
-  document Document @relation(fields: [documentId, documentCreatedAt], references: [id, createdAt])
-
-  @@map("Suggestion")
-}
-
-model Stream {
-  id        String   @id @default(uuid()) @db.Uuid
-  chatId    String   @db.Uuid
-  createdAt DateTime @default(now())
-
-  // Relations
-  chat Chat @relation(fields: [chatId], references: [id])
-
-  @@map("Stream")
 }
 
 // Enums


### PR DESCRIPTION
This pull request removes the `Document`, `Stream`, and `Suggestion` tables and all related references from the database schema and migration files. It also updates the migration script to ensure these tables and their foreign key constraints are dropped, and cleans up related model associations in the Prisma schema.

**Database schema cleanup:**

* Removed the `Document`, `Stream`, and `Suggestion` models from `schema.prisma`, along with all their fields and relations. [[1]](diffhunk://#diff-3af15a46a4156a5898adbc840abd5bcc63f263b02da1069a405966839cb6a2ffL21-L22) [[2]](diffhunk://#diff-3af15a46a4156a5898adbc840abd5bcc63f263b02da1069a405966839cb6a2ffL102) [[3]](diffhunk://#diff-3af15a46a4156a5898adbc840abd5bcc63f263b02da1069a405966839cb6a2ffL121-L165)
* Removed references to `Document`, `Stream`, and `Suggestion` in the `User` and `Chat` models. [[1]](diffhunk://#diff-3af15a46a4156a5898adbc840abd5bcc63f263b02da1069a405966839cb6a2ffL21-L22) [[2]](diffhunk://#diff-3af15a46a4156a5898adbc840abd5bcc63f263b02da1069a405966839cb6a2ffL102)

**Migration updates:**

* Added a migration script that drops the `Document`, `Stream`, and `Suggestion` tables and their associated foreign key constraints.

**Script update:**

* Updated the `db:migrate` script in `package.json` to no longer use the `--skip-generate` flag, ensuring Prisma client is regenerated after migrations.